### PR TITLE
feat: add onPause and onResume hooks to pause and resume the camera

### DIFF
--- a/app/src/main/java/com/revieve/PluginWebViewJavaSample/FullscreenActivity.java
+++ b/app/src/main/java/com/revieve/PluginWebViewJavaSample/FullscreenActivity.java
@@ -235,7 +235,7 @@ public class FullscreenActivity extends AppCompatActivity {
 
     @Override
     protected void onResume () {
-        super.onPause();
+        super.onResume();
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             myWebView.postWebMessage(
                     new WebMessage("{\"type\": \"setCameraPause\", \"payload\": false}"),


### PR DESCRIPTION
This PR adds and example of the usage of https://github.com/revieve/revieve-web-plugin-4/pull/718

It's a new API method that pauses/resumes the liverAR camera. In the android app that's toggled when the app goes to background or foreground.

Here is the APK: https://revieve.slack.com/files/U03DTCL5PJ6/F03L1VDFSMV/app-debug.apk